### PR TITLE
[Feature] add config support

### DIFF
--- a/client/transport/transport.c
+++ b/client/transport/transport.c
@@ -27,6 +27,7 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 
+#include "priskv-config.h"
 #include "priskv-event.h"
 #include "priskv-log.h"
 
@@ -59,18 +60,9 @@ static int priskv_build_check(void)
 static void __attribute__((constructor)) priskv_client_transport_init(void)
 {
     assert(!priskv_build_check());
+    priskv_config_init();
 
-    const char *transport_env = getenv("PRISKV_TRANSPORT");
-    priskv_transport_backend backend = PRISKV_TRANSPORT_BACKEND_RDMA;
-    if (transport_env) {
-        if (strcasecmp(transport_env, "UCX") == 0) {
-            backend = PRISKV_TRANSPORT_BACKEND_UCX;
-        } else if (strcasecmp(transport_env, "RDMA") == 0) {
-            backend = PRISKV_TRANSPORT_BACKEND_RDMA;
-        } else {
-            priskv_log_error("Unknown transport backend: %s\n", transport_env);
-        }
-    }
+    priskv_transport_backend backend = g_config.transport;
 
     priskv_transport_driver *driver = NULL;
     switch (backend) {
@@ -96,10 +88,7 @@ static void __attribute__((constructor)) priskv_client_transport_init(void)
 
     if (driver) {
         g_client_driver = driver;
-        return 0;
     }
-
-    return -1;
 }
 
 void priskv_keyset_free(priskv_keyset *keyset)

--- a/client/transport/transport.h
+++ b/client/transport/transport.h
@@ -37,12 +37,6 @@ extern "C"
 typedef struct priskv_conn_operation priskv_conn_operation;
 typedef struct priskv_transport_conn priskv_transport_conn;
 
-typedef enum priskv_transport_backend {
-    PRISKV_TRANSPORT_BACKEND_UCX,
-    PRISKV_TRANSPORT_BACKEND_RDMA,
-    PRISKV_TRANSPORT_BACKEND_MAX,
-} priskv_transport_backend;
-
 typedef enum priskv_transport_mem_type {
     PRISKV_TRANSPORT_MEM_REQ,
     PRISKV_TRANSPORT_MEM_RESP,

--- a/include/priskv-config.h
+++ b/include/priskv-config.h
@@ -1,0 +1,115 @@
+// Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __PRISKV_CONFIG__
+#define __PRISKV_CONFIG__
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+#include <ucs/config/parser.h>
+#include <ucs/config/types.h>
+#include <ucs/sys/compiler_def.h>
+#include <ucs/sys/preprocessor.h>
+
+/**
+ * @brief Declare config table.
+ * 
+ * @param TABLE Config table.
+ * @param NAME Name of config table.
+ * @param PREFIX Prefix of config table.
+ * @param TYPE Type of config table.
+ */
+#define PRISKV_CONFIG_DECLARE_TABLE(TABLE, NAME, PREFIX, TYPE)                                     \
+    static ucs_config_global_list_entry_t g_##TABLE##_config_entry = {.name = NAME,                \
+                                                                      .prefix = PREFIX,            \
+                                                                      .table = TABLE,              \
+                                                                      .size = sizeof(TYPE),        \
+                                                                      .list = {NULL, NULL},        \
+                                                                      .flags = 0};
+
+#define PRISKV_CONFIG_GET_TABLE(TABLE) &g_##TABLE##_config_entry
+#define PRISKV_ENV_PREFIX "PRISKV_"
+
+/**
+ * @brief Initialize config.
+ */
+void priskv_config_init(void);
+
+/**
+ * @brief Fill options from config entry.
+ * 
+ * @param opts Options to fill.
+ * @param entry Config entry.
+ * @param env_prefix Prefix of environment variables.
+ * @param ignore_errors Ignore errors if set to 1.
+ * @return ucs_status_t UCS_OK on success, otherwise error.
+ */
+ucs_status_t priskv_config_parser_fill_opts(void *opts, ucs_config_global_list_entry_t *entry,
+                                            const char *env_prefix, int ignore_errors);
+
+/**
+ * @brief Release options.
+ * 
+ * @param opts Options to release.
+ * @param fields Config fields.
+ */
+void priskv_config_parser_release_opts(void *opts, ucs_config_field_t *fields);
+
+/**
+ * @brief Set value for option.
+ * 
+ * @param opts Options to set value.
+ * @param fields Config fields.
+ * @param prefix Prefix of option.
+ * @param name Name of option.
+ * @param value Value of option.
+ * @return ucs_status_t UCS_OK on success, otherwise error.
+ */
+ucs_status_t priskv_config_parser_set_value(void *opts, ucs_config_field_t *fields,
+                                            const char *prefix, const char *name,
+                                            const char *value);
+
+typedef enum priskv_transport_backend {
+    PRISKV_TRANSPORT_BACKEND_RDMA,
+    PRISKV_TRANSPORT_BACKEND_UCX,
+    PRISKV_TRANSPORT_BACKEND_MAX,
+} priskv_transport_backend;
+
+typedef struct priskv_client_config {
+    int nqueue;
+    int metadata_update_interval_sec;
+    char *metadata_key;
+    int meta_server_connect_timeout_sec;
+} priskv_client_config_t;
+
+typedef struct priskv_server_config {
+
+} priskv_server_config_t;
+
+typedef struct priskv_config {
+    priskv_transport_backend transport;
+    priskv_client_config_t client;
+    priskv_server_config_t server;
+} priskv_config_t;
+
+extern priskv_config_t g_config;
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __PRISKV_CONFIG__ */

--- a/lib/config.c
+++ b/lib/config.c
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "priskv-config.h"
+#include "priskv-log.h"
+#include <pthread.h>
+
+static const char *priskv_transport_backend_names[] = {[PRISKV_TRANSPORT_BACKEND_RDMA] = "RDMA",
+                                                       [PRISKV_TRANSPORT_BACKEND_UCX] = "UCX",
+                                                       [PRISKV_TRANSPORT_BACKEND_MAX] = NULL};
+
+static ucs_config_field_t priskv_client_config_table[] = {
+    {"NQUEUE", "0", "Number of worker threads for client.",
+     ucs_offsetof(priskv_client_config_t, nqueue),
+     UCS_CONFIG_TYPE_INT},
+    {"METADATA_KEY", "priskv_cluster_metadata", "Key to store cluster metadata.",
+     ucs_offsetof(priskv_client_config_t, metadata_key),
+     UCS_CONFIG_TYPE_STRING},
+    {"METADATA_UPDATE_INTERVAL_SEC", "5", "Interval to update metadata in seconds.",
+     ucs_offsetof(priskv_client_config_t, metadata_update_interval_sec),
+     UCS_CONFIG_TYPE_INT},
+    {"META_SERVER_CONNECT_TIMEOUT_SEC", "5", "Timeout to connect to meta server in seconds.",
+     ucs_offsetof(priskv_client_config_t, meta_server_connect_timeout_sec),
+     UCS_CONFIG_TYPE_INT},
+
+    {NULL}
+};
+
+static ucs_config_field_t priskv_server_config_table[] = {
+    {NULL}
+};
+
+static ucs_config_field_t priskv_config_table[] = {
+    {"TRANSPORT", "RDMA", "PrisKV Transport. Supported transports are [RDMA, UCX].",
+     ucs_offsetof(priskv_config_t, transport),
+     UCS_CONFIG_TYPE_ENUM(priskv_transport_backend_names)},
+
+    {"", "", NULL, ucs_offsetof(priskv_config_t, client),
+     UCS_CONFIG_TYPE_TABLE(priskv_client_config_table)},
+
+    {"", "", NULL, ucs_offsetof(priskv_config_t, server),
+     UCS_CONFIG_TYPE_TABLE(priskv_server_config_table)},
+
+    {NULL}
+};
+
+PRISKV_CONFIG_DECLARE_TABLE(priskv_config_table, "PrisKV Config", NULL, priskv_config_t);
+
+static pthread_once_t g_priskv_config_once = PTHREAD_ONCE_INIT;
+priskv_config_t g_config = {0};
+
+static void priskv_config_init_impl(void)
+{
+    ucs_status_t status = priskv_config_parser_fill_opts(
+        &g_config, PRISKV_CONFIG_GET_TABLE(priskv_config_table), PRISKV_ENV_PREFIX, 1);
+    if (status != UCS_OK) {
+        priskv_log_error("Failed to initialize config: %s\n", ucs_status_string(status));
+    } else {
+        ucs_config_parser_print_opts(
+            stdout, "PrisKV Environment Variables", &g_config, priskv_config_table, NULL,
+            PRISKV_ENV_PREFIX,
+            UCS_CONFIG_PRINT_CONFIG | UCS_CONFIG_PRINT_HEADER | UCS_CONFIG_PRINT_DOC, NULL);
+    }
+}
+
+void priskv_config_init(void)
+{
+    pthread_once(&g_priskv_config_once, priskv_config_init_impl);
+}
+
+ucs_status_t priskv_config_parser_fill_opts(void *opts, ucs_config_global_list_entry_t *entry,
+                                            const char *env_prefix, int ignore_errors)
+{
+    return ucs_config_parser_fill_opts(opts, entry, env_prefix, ignore_errors);
+}
+
+void priskv_config_parser_release_opts(void *opts, ucs_config_field_t *fields)
+{
+    ucs_config_parser_release_opts(opts, fields);
+}
+
+ucs_status_t priskv_config_parser_set_value(void *opts, ucs_config_field_t *fields,
+                                            const char *prefix, const char *name, const char *value)
+{
+
+    return ucs_config_parser_set_value(opts, fields, prefix, name, value);
+}

--- a/server/test/Makefile
+++ b/server/test/Makefile
@@ -40,7 +40,7 @@ UCX_CFLAGS = $(shell pkg-config --cflags ucx)
 UCX_LIBS = $(shell pkg-config --libs ucx)
 ifeq ($(shell pkg-config --exists ucx; echo $$?),0)
 $(TEST_KV): $(OBJS)
-	$(CC) test_kv.c ../../lib/workqueue.c ../../lib/threads.c ../../lib/event.c ../../lib/ucx.c ../memory.c ../kv.c ../slab.c ../buddy.c ../crc.c ../../lib/log.c ../backend/backend.c ../transport/transport.c ../transport/rdma.c ../transport/ucx.c ../tiering.c ../acl.c $(CFLAGS) $(UCX_CFLAGS) -o $(TEST_KV) -lmount -lrdmacm -libverbs $(UCX_LIBS)
+	$(CC) test_kv.c ../../lib/workqueue.c ../../lib/threads.c ../../lib/event.c ../../lib/ucx.c ../../lib/config.c ../memory.c ../kv.c ../slab.c ../buddy.c ../crc.c ../../lib/log.c ../backend/backend.c ../transport/transport.c ../transport/rdma.c ../transport/ucx.c ../tiering.c ../acl.c $(CFLAGS) $(UCX_CFLAGS) -o $(TEST_KV) -lmount -lrdmacm -libverbs $(UCX_LIBS)
 else
 $(TEST_KV):
 	@echo "UCX not available, skip $(TEST_KV)"
@@ -48,7 +48,7 @@ endif
 
 ifeq ($(shell pkg-config --exists ucx; echo $$?),0)
 $(TEST_KV_MT): $(OBJS)
-	$(CC) test_kv_mt.c ../../lib/workqueue.c ../../lib/threads.c ../../lib/event.c ../../lib/ucx.c ../memory.c ../kv.c ../slab.c ../buddy.c ../crc.c ../../lib/log.c ../backend/backend.c ../transport/transport.c ../transport/rdma.c ../transport/ucx.c ../tiering.c ../acl.c $(CFLAGS) $(UCX_CFLAGS) -o $(TEST_KV_MT) -lmount -lrdmacm -libverbs $(UCX_LIBS)
+	$(CC) test_kv_mt.c ../../lib/workqueue.c ../../lib/threads.c ../../lib/event.c ../../lib/ucx.c ../../lib/config.c ../memory.c ../kv.c ../slab.c ../buddy.c ../crc.c ../../lib/log.c ../backend/backend.c ../transport/transport.c ../transport/rdma.c ../transport/ucx.c ../tiering.c ../acl.c $(CFLAGS) $(UCX_CFLAGS) -o $(TEST_KV_MT) -lmount -lrdmacm -libverbs $(UCX_LIBS)
 else
 $(TEST_KV_MT):
 	@echo "UCX not available, skip $(TEST_KV_MT)"
@@ -62,7 +62,7 @@ $(TEST_ACL): $(OBJS)
 
 ifeq ($(shell pkg-config --exists ucx; echo $$?),0)
 $(TEST_KV_EXPIRE_ROUTINE): $(OBJS)
-	$(CC) test_kv_expire_routine.c ../../lib/workqueue.c ../../lib/threads.c ../../lib/event.c ../../lib/ucx.c ../memory.c ../kv.c ../slab.c ../buddy.c ../crc.c ../../lib/log.c ../backend/backend.c ../transport/transport.c ../transport/rdma.c ../transport/ucx.c ../tiering.c ../acl.c $(CFLAGS) $(UCX_CFLAGS) -o $(TEST_KV_EXPIRE_ROUTINE) -lmount -lpthread -lrdmacm -libverbs $(UCX_LIBS)
+	$(CC) test_kv_expire_routine.c ../../lib/workqueue.c ../../lib/threads.c ../../lib/event.c ../../lib/ucx.c ../../lib/config.c ../memory.c ../kv.c ../slab.c ../buddy.c ../crc.c ../../lib/log.c ../backend/backend.c ../transport/transport.c ../transport/rdma.c ../transport/ucx.c ../tiering.c ../acl.c $(CFLAGS) $(UCX_CFLAGS) -o $(TEST_KV_EXPIRE_ROUTINE) -lmount -lpthread -lrdmacm -libverbs $(UCX_LIBS)
 else
 $(TEST_KV_EXPIRE_ROUTINE):
 	@echo "UCX not available, skip $(TEST_KV_EXPIRE_ROUTINE)"

--- a/server/transport/transport.c
+++ b/server/transport/transport.c
@@ -16,6 +16,7 @@
 #include <strings.h>
 
 #include "../kv.h"
+#include "priskv-config.h"
 #include "priskv-event.h"
 #include "priskv-log.h"
 #include "priskv-threads.h"
@@ -42,17 +43,9 @@ void priskv_tiering_del(priskv_tiering_req *treq);
 
 static void __attribute__((constructor)) priskv_server_transport_init(void)
 {
-    const char *transport_env = getenv("PRISKV_TRANSPORT");
-    priskv_transport_backend backend = PRISKV_TRANSPORT_BACKEND_RDMA;
-    if (transport_env) {
-        if (strcasecmp(transport_env, "UCX") == 0) {
-            backend = PRISKV_TRANSPORT_BACKEND_UCX;
-        } else if (strcasecmp(transport_env, "RDMA") == 0) {
-            backend = PRISKV_TRANSPORT_BACKEND_RDMA;
-        } else {
-            priskv_log_error("Unknown transport backend: %s\n", transport_env);
-        }
-    }
+    priskv_config_init();
+
+    priskv_transport_backend backend = g_config.transport;
 
     priskv_transport_driver *driver = NULL;
     switch (backend) {
@@ -78,10 +71,7 @@ static void __attribute__((constructor)) priskv_server_transport_init(void)
 
     if (driver) {
         g_transport_driver = driver;
-        return 0;
     }
-
-    return -1;
 }
 
 int priskv_transport_listen(char **addr, int naddr, int port, void *kv,

--- a/server/transport/transport.h
+++ b/server/transport/transport.h
@@ -49,12 +49,6 @@ extern "C"
 
 extern uint32_t g_slow_query_threshold_latency_us;
 
-typedef enum priskv_transport_backend {
-    PRISKV_TRANSPORT_BACKEND_UCX,
-    PRISKV_TRANSPORT_BACKEND_RDMA,
-    PRISKV_TRANSPORT_BACKEND_MAX,
-} priskv_transport_backend;
-
 typedef struct priskv_transport_stats {
     uint64_t ops;
     uint64_t bytes;


### PR DESCRIPTION
## Pull Request Description
Add a well-managed way to get env variable based configurations. After initialization, both client and server sides will display all priskv env variables like the following:
<img width="1315" height="936" alt="image" src="https://github.com/user-attachments/assets/087cd62c-7e10-469f-9c44-6dda37561713" />

## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to PrisKV! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to PrisKV's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>