### PR TITLE
[Feature] add logging config

### DIFF
--- a/client/benchmark.c
+++ b/client/benchmark.c
@@ -90,7 +90,7 @@ static uint64_t g_total_value_size = 0;
 
 static int g_rows, g_cols;
 
-static priskv_log_level g_log_level = priskv_log_notice;
+static priskv_log_level g_log_level = priskv_log_level_max;
 static const char *g_log_file = NULL;
 static priskv_logger *g_logger;
 

--- a/client/client.c
+++ b/client/client.c
@@ -46,7 +46,7 @@ static const char *raddr;
 static int rport = ('H' << 8 | 'P');
 static const char *laddr;
 static int lport;
-static priskv_log_level log_level = priskv_log_notice;
+static priskv_log_level log_level = priskv_log_level_max;
 static priskv_logger *g_logger;
 static const char *log_file = NULL;
 static int g_exit = 0;

--- a/cluster/client/benchmark.c
+++ b/cluster/client/benchmark.c
@@ -91,7 +91,7 @@ static uint64_t g_total_value_size = 0;
 
 static int g_rows, g_cols;
 
-static priskv_log_level g_log_level = priskv_log_notice;
+static priskv_log_level g_log_level = priskv_log_level_max;
 static const char *g_log_file = NULL;
 static priskv_logger *g_logger;
 

--- a/include/priskv-config.h
+++ b/include/priskv-config.h
@@ -25,6 +25,8 @@ extern "C"
 #include <ucs/sys/compiler_def.h>
 #include <ucs/sys/preprocessor.h>
 
+#include "priskv-log.h"
+
 /**
  * @brief Declare config table.
  * 
@@ -100,8 +102,14 @@ typedef struct priskv_server_config {
 
 } priskv_server_config_t;
 
+typedef struct priskv_logging_config {
+    priskv_log_level log_level;
+    char *log_file;
+} priskv_logging_config_t;
+
 typedef struct priskv_config {
     priskv_transport_backend transport;
+    priskv_logging_config_t logging;
     priskv_client_config_t client;
     priskv_server_config_t server;
 } priskv_config_t;

--- a/include/priskv-log.h
+++ b/include/priskv-log.h
@@ -80,6 +80,14 @@ void priskv_logger_printf(priskv_logger *logger, priskv_log_level level, const c
              "    (multifile:PATH)\tprint to multiple files based on log level\n" __prefix         \
              "    (unix:PATH)\t\tprint to unix socket\n"
 
+extern const char *priskv_log_level_str[];
+extern priskv_logger *g_default_logger;
+
+static inline void priskv_logger_default_fn(priskv_log_level level, const char *msg)
+{
+    priskv_logger_printf(g_default_logger, level, "%s", msg);
+}
+
 #if defined(__cplusplus)
 }
 #endif

--- a/server/memfile.c
+++ b/server/memfile.c
@@ -44,7 +44,7 @@ static uint32_t max_key = PRISKV_TRANSPORT_DEFAULT_KEY;
 static uint32_t value_block_size = PRISKV_TRANSPORT_DEFAULT_VALUE_BLOCK_SIZE;
 static uint64_t value_block = PRISKV_TRANSPORT_DEFAULT_VALUE_BLOCK;
 static uint8_t threads = 1;
-static priskv_log_level log_level = priskv_log_notice;
+static priskv_log_level log_level = priskv_log_level_max;
 static char *memfile;
 static const char *operation = "info";
 

--- a/server/server.c
+++ b/server/server.c
@@ -54,7 +54,7 @@ static uint8_t threads = 1;
 static uint32_t thread_flags;
 static uint32_t expire_routine_interval = PRISKV_KV_DEFAULT_EXPIRE_ROUTINE_INTERVAL;
 static const char *memfile;
-static priskv_log_level log_level = priskv_log_notice;
+static priskv_log_level log_level = priskv_log_level_max;
 static const char *g_log_file = NULL;
 static priskv_logger *g_logger = NULL;
 static priskv_transport_conn_cap conn_cap = {.max_sgl = PRISKV_TRANSPORT_DEFAULT_SGL,


### PR DESCRIPTION
## Pull Request Description
Add logging config support, such that we can configure priskv logging without relying on program arguments.
Supported configurations:
<img width="1205" height="433" alt="image" src="https://github.com/user-attachments/assets/fa704feb-0ac9-47d2-90ac-b2d8e91f48d2" />


## Related Issues
Resolves: #[Insert issue number(s)]

**Important: Before submitting, please complete the description above and review the checklist below.**

---

<details>
<summary><strong>Contribution Guidelines (Expand for Details)</strong></summary>

<p>We appreciate your contribution to PrisKV! To ensure a smooth review process and maintain high code quality, please adhere to the following guidelines:</p>

<h3>Pull Request Title Format</h3>
<p>Your PR title should start with one of these prefixes to indicate the nature of the change:</p>
<ul>
    <li><code>[Bug]</code>: Corrections to existing functionality</li>
    <li><code>[CI]</code>: Changes to build process or CI pipeline</li>
    <li><code>[Docs]</code>: Updates or additions to documentation</li>
    <li><code>[API]</code>: Modifications to PrisKV's API or interface</li>
    <li><code>[CLI]</code>: Changes or additions to the Command Line Interface</li>
    <li><code>[Misc]</code>: For changes not covered above (use sparingly)</li>
</ul>
<p><em>Note: For changes spanning multiple categories, use multiple prefixes in order of importance.</em></p>

<h3>Submission Checklist</h3>
<ul>
    <li>[ ] PR title includes appropriate prefix(es)</li>
    <li>[ ] Changes are clearly explained in the PR description</li>
    <li>[ ] New and existing tests pass successfully</li>
    <li>[ ] Code adheres to project style and best practices</li>
    <li>[ ] Documentation updated to reflect changes (if applicable)</li>
    <li>[ ] Thorough testing completed, no regressions introduced</li>
</ul>

<p>By submitting this PR, you confirm that you've read these guidelines and your changes align with the project's contribution standards.</p>

</details>